### PR TITLE
feat: Add new unindexed nix flakes and fix some reserved names

### DIFF
--- a/docs/adding-a-flake.md
+++ b/docs/adding-a-flake.md
@@ -17,6 +17,16 @@ gitlab:owner/repo
 - Any other flake reference Nix can fetch, including a specific ref. It is
   resolved with `nix flake metadata` and pinned to an exact revision.
 
+Write a GitHub repository in the bare form, even though `github:owner/repo`
+names the same thing. The two take different paths through the pipeline. A
+candidate is named by `tools/resolve.py`, so it goes through the contention
+rule, `names.txt` and the stickiness rule below. A resolved reference skips
+all three: `tools/manual.py` names it after its repository and nothing
+else, `names.txt` cannot reach it, and two repositories of the same name
+both arrive as the same attribute. Reach for the prefixed form when the
+bare one cannot say what you mean — another forge, or a tag or branch you
+want pinned instead of the default one.
+
 A flake listed here is also exempt from `tools/classify.py`, which guesses
 from the repository name which flakes are somebody's own machine
 configuration. That guess is wrong in both directions: `catppuccin/nix` is

--- a/docs/building-the-index.md
+++ b/docs/building-the-index.md
@@ -291,6 +291,24 @@ re-pinning, which avoids downloading a tree per flake, but
 of 11,429 rows took 42 minutes at 16 jobs, not the few minutes a short
 sample suggests. Run it locally, not in CI.
 
+### Which Nix
+
+The pipeline is developed and run against upstream Nix, and `check.yml`
+installs that deliberately. Determinate Nix enables lazy trees by default,
+which changes what `nix flake metadata` returns for the same flake: `locked`
+can come back without a `narHash`, because nothing hashed the tree, and the
+store path the metadata reports is never materialised. Pins are made of
+both. `pin.py` covers the difference — a missing hash is recovered with a
+prefetch, and the committed lock is read through `fetchTree` when the path
+is not on disk — so a run under Determinate Nix produces the same rows,
+more slowly.
+
+Errors are the part that does not carry over. A pin that fails locally with
+a message about the git object or the fetched tree, on a flake with no other
+reason to fail, is worth re-checking on upstream Nix before it is written
+down as a failure. `nix flake metadata --json github:owner/repo` is the
+whole test.
+
 ## Continuous integration
 
 `update.yml` runs the pipeline daily, cuts a data release for the databases

--- a/manual.txt
+++ b/manual.txt
@@ -1,23 +1,22 @@
 # Flakes added by hand, outside GitHub search. See tools/manual.py.
 # One per line: "owner/repo", or any flake ref Nix can fetch.
 
-github:AdnanHodzic/auto-cpufreq
-github:b3nj5m1n/xdg-ninja
-github:dfrankland/envoluntary
-github:emilien-jegou/oyui
-github:fzakaria/nix-auto-follow
-github:fzakaria/nixpkgs-multiverse
-github:guibou/tsui
-github:helix-editor/helix
-github:idursun/jjui
-github:Mic92/direnv-instant
-github:mightyiam/files
-github:nikitawootten/flake-graph
-github:nix-community/nix-direnv
-github:nix-community/nix-unit
-github:NotAShelf/flint
+AdnanHodzic/auto-cpufreq
+b3nj5m1n/xdg-ninja
+dfrankland/envoluntary
+emilien-jegou/oyui
+fzakaria/nix-auto-follow
+fzakaria/nixpkgs-multiverse
 github:roman/nixDir/v3
-github:sini/files
+guibou/tsui
+helix-editor/helix
+idursun/jjui
+Mic92/direnv-instant
+nikitawootten/flake-graph
+nix-community/nix-direnv
+nix-community/nix-unit
+NotAShelf/flint
+sini/files
 
 # Reported missing in issue #2. GitHub calls the primary language of these
 # three Rust and Haskell, and none carries a nix topic, so no query in

--- a/manual.txt
+++ b/manual.txt
@@ -1,9 +1,23 @@
 # Flakes added by hand, outside GitHub search. See tools/manual.py.
 # One per line: "owner/repo", or any flake ref Nix can fetch.
 
-fzakaria/nix-auto-follow
-fzakaria/nixpkgs-multiverse
+github:AdnanHodzic/auto-cpufreq
+github:b3nj5m1n/xdg-ninja
+github:dfrankland/envoluntary
+github:emilien-jegou/oyui
+github:fzakaria/nix-auto-follow
+github:fzakaria/nixpkgs-multiverse
+github:guibou/tsui
+github:helix-editor/helix
+github:idursun/jjui
+github:Mic92/direnv-instant
+github:mightyiam/files
+github:nikitawootten/flake-graph
+github:nix-community/nix-direnv
+github:nix-community/nix-unit
+github:NotAShelf/flint
 github:roman/nixDir/v3
+github:sini/files
 
 # Reported missing in issue #2. GitHub calls the primary language of these
 # three Rust and Haskell, and none carries a nix topic, so no query in

--- a/names.txt
+++ b/names.txt
@@ -61,6 +61,7 @@ nix-community/stylix                stylix
 Gerg-L/spicetify-nix                spicetify-nix
 SenchoPens/base16.nix               base16-nix
 nix-community/kickstart-nix.nvim    kickstart-nix-nvim
+helix-editor/helix                  helix
 0xc000022070/zen-browser-flake      zen-browser-flake
 
 # Tooling: build, deploy, cache, lint.
@@ -95,9 +96,9 @@ yunfachi/denix                      denix
 NixOS/templates                     templates
 the-nix-way/dev-templates           dev-templates
 
-# Misclassification of derived names. They say nothing about the project.
-# Such repositories may need to also be listed in manual.txt because classify.py
-# may read their names as personal configs; the same names are useless as API.
+# Derived names that say nothing about the project. Some of these are also
+# in manual.txt, because classify.py reads their repository names as
+# personal configs; the same names are useless as API.
 catppuccin/nix                      catppuccin
 nixified-ai/flake                   nixified-ai
 xremap/nix-flake                    xremap
@@ -111,5 +112,4 @@ xremap/nix-flake                    xremap
 # 149 mean by firefox-addons is a subdirectory of a GitLab repository that
 # the index does not carry at all.
 akirak/git-hooks                    -
-izzqz/helix                         -
 seadome/firefox-addons              -

--- a/names.txt
+++ b/names.txt
@@ -28,21 +28,22 @@ numtide/flake-utils                 flake-utils
 NixOS/flake-compat                  flake-compat
 
 # The flakes people write into a NixOS or nix-darwin configuration.
-nix-community/home-manager          home-manager
-nix-darwin/nix-darwin               nix-darwin
+anduril/jetpack-nixos               jetpack-nixos
+Infinidoge/nix-minecraft            nix-minecraft
+Jovian-Experiments/Jovian-NixOS     jovian-nixos
+Maroka-chan/VPN-Confinement         vpn-confinement
+mightyiam/files                     files
 nix-community/disko                 disko
-NixOS/nixos-hardware                nixos-hardware
-nix-community/nixos-anywhere        nixos-anywhere
-nix-community/NixOS-WSL             nixos-wsl
-nix-community/nix-on-droid          nix-on-droid
+nix-community/home-manager          home-manager
 nix-community/impermanence          impermanence
 nix-community/lanzaboote            lanzaboote
-Jovian-Experiments/Jovian-NixOS     jovian-nixos
-anduril/jetpack-nixos               jetpack-nixos
-numtide/system-manager              system-manager
+nix-community/nix-on-droid          nix-on-droid
+nix-community/nixos-anywhere        nixos-anywhere
+nix-community/NixOS-WSL             nixos-wsl
 nix-community/robotnix              robotnix
-Infinidoge/nix-minecraft            nix-minecraft
-Maroka-chan/VPN-Confinement         vpn-confinement
+nix-darwin/nix-darwin               nix-darwin
+NixOS/nixos-hardware                nixos-hardware
+numtide/system-manager              system-manager
 SEIAROTg/quadlet-nix                quadlet-nix
 
 # Development environments and shells.
@@ -94,11 +95,12 @@ yunfachi/denix                      denix
 NixOS/templates                     templates
 the-nix-way/dev-templates           dev-templates
 
-# Derived names that say nothing about the project. Both repositories are
-# in manual.txt because classify.py reads their names as personal configs;
-# the same names are useless as API.
-nixified-ai/flake                   nixified-ai
+# Misclassification of derived names. They say nothing about the project.
+# Such repositories may need to also be listed in manual.txt because classify.py
+# may read their names as personal configs; the same names are useless as API.
 catppuccin/nix                      catppuccin
+nixified-ai/flake                   nixified-ai
+xremap/nix-flake                    xremap
 
 # Bare names taken away. Each of these is the only repository of its name,
 # so the contention rule leaves it holding one that indexed flakes
@@ -109,4 +111,5 @@ catppuccin/nix                      catppuccin
 # 149 mean by firefox-addons is a subdirectory of a GitLab repository that
 # the index does not carry at all.
 akirak/git-hooks                    -
+izzqz/helix                         -
 seadome/firefox-addons              -

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -64,6 +64,24 @@ class TestUnifyNames(unittest.TestCase):
         self.assertIn("home", indexed_only)
         self.assertNotIn("home", generate.unify_names(self.INDEXED, self.RESOLVED, {}))
 
+    def test_a_line_the_index_has_not_applied_yet_is_not_an_override_key(self):
+        # resolve.py applies names.txt, so a line committed today reaches
+        # the index on the next pipeline run and not before. Until then
+        # the name is still on the repository the line moves it off, and
+        # vouching for it would substitute exactly that repository.
+        pending = {
+            ("nix-community", "nixvim"): "nixvim",
+            ("elsewhere", "nixvim"): "nixvim",
+        }
+        self.assertNotIn(
+            "nixvim-elsewhere",
+            generate.unify_names(
+                self.INDEXED + [row("elsewhere", "nixvim", "nixvim-elsewhere")],
+                self.RESOLVED,
+                pending,
+            ),
+        )
+
     def test_a_flake_outside_the_index_is_never_an_override_key(self):
         keys = generate.unify_names(self.INDEXED, self.RESOLVED, {})
         self.assertNotIn("nixvim-elsewhere", keys)

--- a/tools/generate.py
+++ b/tools/generate.py
@@ -85,12 +85,19 @@ def unify_names(indexed, resolved, reserved):
     Contention is counted over the whole database rather than the index,
     because a repository classified personal still means the name does not
     identify one flake.
+
+    A line counts only once the repository it names actually holds the
+    name. resolve.py is what applies names.txt to a row, so between the
+    commit that adds a line and the next pipeline run the index still
+    holds the old assignment: a line handing "helix" to helix-editor/helix
+    would otherwise vouch for an input name that izzqz/helix is still
+    sitting on, which is the substitution the line exists to stop.
     """
     claims = collections.Counter(sanitize(row["repo"]) for row in resolved)
     names = [
         row["name"]
         for row in indexed
-        if (row["owner"].lower(), row["repo"].lower()) in reserved
+        if reserved.get((row["owner"].lower(), row["repo"].lower())) == row["name"]
         or claims[sanitize(row["repo"])] <= 1
     ]
     return sorted(names)

--- a/unify.json
+++ b/unify.json
@@ -2848,6 +2848,7 @@
   "file-fuzzer",
   "file-templates",
   "fileicon-nix",
+  "files",
   "filnix",
   "filosofo",
   "filterfs",


### PR DESCRIPTION
This PR adds a few new, previously unindexed Nix flakes and fixes some reserved names.

`manual.txt`: Add 13 previously unindexed flakes (`auto-cpufreq`, `xdg-ninja`, `envoluntary`, `oyui`, `tsui`, `helix`, `jjui`, `direnv-instant`, `flake-graph`, `nix-direnv`, `nix-unit`, `flint`, `sini/files`).

`names.txt`:
  - Reserve name "xremap" for `github:xremap/nix-flake`.
  - Hide `github:izzqz/helix` behind its owner qualification, making it lose the bare `helix` name to `github:helix-editor/helix`.
  - Reserve naě "files" for `github:migthyiam/files`, but index `github:sini/files` under its owner-qualified name.

I also ordered the lines in the `{manual,names}.txt` files in the sections I touched alphabetically. This prevents future merge conflicts because there are fewer cases where multiple PRs append to the end of the section simultaneously.

# Questions

1. Should I commit anything else from the generated files? It is somewhat unclear what the contributing workflow should look like to avoid breaking the flake before the next automated index update. When doing the index update myself, I was getting results from modifying flakes not touched by this PR, so I opted not to commit anything from them. 

2. As it is now, the `github:helix-editor/helix` flake fails to index properly, seemingly due to an invalid git commit tree upstream in the repo. It might be an issue with the code indexing the flakes here. Not sure. Should I keep it so that `github:helix-editor/helix` is at least tracked as a flake pinning failure to be fixed?

3. `github:{sini,mightyiam}/files` should be, in my opinion, both indexed (mightyiam's version already was; sini's is a hard fork from mightyiam's providing different functionality), but `github:mightyiam/files` should probably be the one taking the short resolved name `files`. Unless I configured the `.txt` files incorrectly, this should, to my understanding, be the correct resolution for the reserved short name, which seems to be misbehaving. LLM says there are issues with merging the `.txt` lists to the index. Since I do not understand the codebase, let me know if you want to look at it yourself, or if I should drop these for the time being.
<details><summary>LLM suggested fix and test case (I have no idea about correctness)</summary>

```diff
From 34a1794c527d755a2279a55f04eb3265dbd348c0 Mon Sep 17 00:00:00 2001
From: =?UTF-8?q?David=20Chocholat=C3=BD?= <chocholaty.david@protonmail.com>
Date: Thu, 3 Sep 2026 10:29:53 +0200
Subject: [PATCH]

---
 tests/test_contested_names.py | 170 ++++++++++++++++++++++++++++++++++
 tools/generate.py             |  19 +++-
 tools/resolve.py              |  18 +++-
 3 files changed, 203 insertions(+), 4 deletions(-)
 create mode 100644 tests/test_contested_names.py

diff --git a/tests/test_contested_names.py b/tests/test_contested_names.py
new file mode 100644
index 0000000..d14fd33
--- /dev/null
+++ b/tests/test_contested_names.py
@@ -0,0 +1,170 @@
+"""Tests that two repositories of the same name cannot collapse into one
+attribute, over the pipeline's two ends.
+
+mightyiam/files and sini/files are both listed in manual.txt, and
+tools/manual.py names a row after its repository and nothing else, so both
+arrived as "files" and generate.py silently kept whichever the library
+happened to hold last: mightyiam/files was absent from index.json with
+nothing said about it. Two guards, and this covers both.
+
+The scripts run as subprocesses over files in a temporary directory. No
+test here runs Nix or touches the network: resolve.py is given no
+candidates, so it issues no GraphQL query.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+TOOLS = os.path.join(os.path.dirname(__file__), "..", "tools")
+
+NAMES = "mightyiam/files files\n"
+
+
+def write(path, text):
+    with open(path, "w") as fh:
+        fh.write(text)
+
+
+def write_jsonl(path, rows):
+    write(path, "".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+
+
+def row(owner, name, rev="0" * 40):
+    """A resolved row for owner/files, as tools/manual.py writes them."""
+    return {
+        "name": name,
+        "owner": owner,
+        "repo": "files",
+        "rev": rev,
+        "url": f"github:{owner}/files/{rev}",
+        "inputs": [],
+        "stars": 0,
+        "manual": True,
+        "resolved_at": 0,
+    }
+
+
+def run(script, args, cwd, stdin=""):
+    return subprocess.run(
+        [sys.executable, os.path.join(TOOLS, script), *args],
+        cwd=cwd,
+        input=stdin,
+        capture_output=True,
+        text=True,
+    )
+
+
+# The two manual entries, as tools/manual.py resolves them: one name each,
+# both derived from the repository name, and so the same name twice.
+MERGED = [row("mightyiam", "files", "a" * 40), row("sini", "files", "b" * 40)]
+
+
+class TestResolveNamesMergedRows(unittest.TestCase):
+    """Tests that names.txt reaches the rows tools/manual.py resolved.
+    They bypass choose_name entirely -- they are not candidates -- so
+    without apply_reserved over them a line has no effect at all."""
+
+    def resolve(self, names):
+        with tempfile.TemporaryDirectory() as tmp:
+            write_jsonl(os.path.join(tmp, "merged.jsonl"), MERGED)
+            write_jsonl(os.path.join(tmp, "known.jsonl"), [])
+            write(os.path.join(tmp, "names.txt"), names)
+            proc = run(
+                "resolve.py",
+                [
+                    "--known",
+                    "known.jsonl",
+                    "--merge",
+                    "merged.jsonl",
+                    "--names",
+                    "names.txt",
+                    "--refresh-oldest",
+                    "0",
+                    "--recheck-oldest",
+                    "0",
+                ],
+                tmp,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            rows = [json.loads(l) for l in proc.stdout.splitlines() if l.strip()]
+            return {(r["owner"], r["repo"]): r["name"] for r in rows}
+
+    def test_without_a_line_both_rows_hold_the_same_name(self):
+        # The state that produced the bug, so the fix is what the next
+        # assertions observe and not something else about the run.
+        self.assertEqual(
+            self.resolve(""),
+            {("mightyiam", "files"): "files", ("sini", "files"): "files"},
+        )
+
+    def test_the_repository_a_line_names_holds_the_bare_name(self):
+        self.assertEqual(self.resolve(NAMES)[("mightyiam", "files")], "files")
+
+    def test_the_other_is_displaced_to_its_qualified_name(self):
+        self.assertEqual(self.resolve(NAMES)[("sini", "files")], "files-sini")
+
+
+class TestGenerateRefusesDuplicates(unittest.TestCase):
+    """Tests that a library holding one name twice stops the run rather
+    than writing an index that leaves one of the two flakes out."""
+
+    def generate(self, library):
+        with tempfile.TemporaryDirectory() as tmp:
+            write_jsonl(os.path.join(tmp, "library.jsonl"), library)
+            write_jsonl(
+                os.path.join(tmp, "pins.jsonl"),
+                [
+                    {
+                        "ref": r["url"],
+                        "name": r["name"],
+                        "locked": {
+                            "type": "github",
+                            "owner": r["owner"],
+                            "repo": "files",
+                            "rev": r["rev"],
+                        },
+                    }
+                    for r in library
+                ],
+            )
+            write_jsonl(os.path.join(tmp, "failures.jsonl"), [])
+            write_jsonl(os.path.join(tmp, "resolved.jsonl"), library)
+            write(os.path.join(tmp, "names.txt"), NAMES)
+            write(os.path.join(tmp, "blocklist.txt"), "")
+            write(os.path.join(tmp, "README.md"), "")
+            os.mkdir(os.path.join(tmp, "locks"))
+            proc = run("generate.py", [], tmp)
+            index = os.path.join(tmp, "index.json")
+            written = None
+            if os.path.exists(index):
+                with open(index) as fh:
+                    written = json.load(fh)
+            return proc, written
+
+    def test_a_duplicate_name_fails_the_run(self):
+        proc, written = self.generate([row("mightyiam", "files"), row("sini", "files")])
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("duplicate index name 'files'", proc.stderr)
+        # Both repositories named, so the message says what to fix.
+        self.assertIn("mightyiam/files", proc.stderr)
+        self.assertIn("sini/files", proc.stderr)
+        # And no index written from the losing half of the collision.
+        self.assertIsNone(written)
+
+    def test_distinct_names_both_reach_the_index(self):
+        proc, written = self.generate(
+            [row("mightyiam", "files"), row("sini", "files-sini")]
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(
+            {name: entry["locked"]["owner"] for name, entry in written.items()},
+            {"files": "mightyiam", "files-sini": "sini"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
diff --git a/tools/generate.py b/tools/generate.py
index f05d89b..727a3e4 100755
--- a/tools/generate.py
+++ b/tools/generate.py
@@ -169,8 +169,10 @@ def main():
             last_good[pin["name"]] = pin
 
     index = {}
-    # The library rows that made it in, for the override map below.
+    # The library rows that made it in, for the override map below, and by
+    # the name each one holds, so a collision can name both repositories.
     indexed = []
+    holder = {}
     # Every reference the output still needs: the library's own, plus the
     # older ones the fallback keeps alive so pruning does not collect them.
     keep_refs = {}
@@ -205,7 +207,22 @@ def main():
         if pin.get("lock"):
             entry["lock"] = True
             stats["stored_locks"] += 1
+        # One name, one flake. A second row for a name would take the
+        # attribute from the first and leave that flake out of the index
+        # with nothing said about it, so this is a stop, not a warning:
+        # names.txt decides which repository holds a contested name.
+        if name in index:
+            other = holder[name]
+            print(
+                f"# duplicate index name {name!r}: "
+                f"{other['owner']}/{other['repo']} and "
+                f"{row['owner']}/{row['repo']}. Assign one of them a name "
+                f"in {args.names}.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         index[name] = entry
+        holder[name] = row
         indexed.append(row)
         stats["indexed"] += 1
 
diff --git a/tools/resolve.py b/tools/resolve.py
index 46a7813..a5ba66b 100755
--- a/tools/resolve.py
+++ b/tools/resolve.py
@@ -419,9 +419,21 @@ def main():
     # the same repo all yield to them. Their names join the taken set so a
     # new candidate cannot claim a name a merged row already uses, but a
     # name some known repo already holds stays with that repo.
-    merged, merged_names = load_known(args.merge)
-    for name, repo_key in merged_names.items():
-        taken.setdefault(name, repo_key)
+    merged, _ = load_known(args.merge)
+
+    # tools/manual.py names a row after its repository and nothing else, so
+    # two manually listed repositories of the same name both arrive as the
+    # same attribute and generate.py would keep whichever came last.
+    # names.txt is what decides between them, here as for known rows.
+    merged_assigned, merged_displaced = apply_reserved(merged, reserved)
+    if merged_assigned or merged_displaced:
+        print(
+            f"# names: assigned {merged_assigned} merged row(s) a reserved "
+            f"name, displaced {merged_displaced}",
+            file=sys.stderr,
+        )
+    for row in merged.values():
+        taken.setdefault(row["name"], (row["owner"], row["repo"]))
 
     # Repositories checked before and found unusable. A row that names a
     # repository the database now holds is dropped on sight: success is
-- 
2.55.0


```

</details> 
